### PR TITLE
Changes to scaling to be able to read float values from XML.

### DIFF
--- a/src/map-decl/scaling.cpp
+++ b/src/map-decl/scaling.cpp
@@ -34,8 +34,8 @@ void Scaling::fromXML(const QDomElement &el)
     {
         format = el.attribute("format");
         increment = el.attribute("inc").toFloat(nullptr);
-        min = el.attribute("min").toInt(nullptr);
-        max = el.attribute("max").toInt(nullptr);
+        min = el.attribute("min").toFloat(nullptr);
+        max = el.attribute("max").toFloat(nullptr);
         toexpr = el.attribute("toexpr");
         frexpr = el.attribute("frexpr");
         if (el.attribute("endian") == "big")

--- a/src/map-decl/scaling.h
+++ b/src/map-decl/scaling.h
@@ -31,8 +31,8 @@ public:
     QString frexpr;
     QString format;
     bool endian = false;
-    int min = 0;
-    int max = 0;
+    float min = 0.0;
+    float max = 0.0;
     float increment = 0;
     QString Original;
     QString Patched;


### PR DESCRIPTION
If values are defined as float in the scaling section of the XML then they are not read and return zero. Changed to float type and updated parsing code in fromXML.